### PR TITLE
Attempt #2 at Switching FDP mode with Deconstruction planner in hand. 

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -25,6 +25,9 @@ end
 
 -- Shows the left frame GUI element
 function gui_show_frame(player)
+  local gui_frame = player.gui.left["fdp-gui-frame"]
+  if gui_frame then return end
+
   local gui_frame = player.gui.left.add{
     type = "frame",
     caption = {"fdp-gui-frame-caption"},
@@ -138,9 +141,21 @@ script.on_event(FDP_EVENTS.on_gui_clicked, function(event)
       if event.player.cursor_stack.name == "deconstruction-planner" then
         --normal, target, exclude
         local new_mode = nil
-        if global["config"][event.player.index]["mode"] == "normal" then new_mode = "target" end
-        if global["config"][event.player.index]["mode"] == "target" then new_mode = "exclude" end
-        if global["config"][event.player.index]["mode"] == "exclude" then new_mode = "normal" end
+        if global["config"][event.player.index]["mode"] == "normal" then
+          new_mode = "target"
+          global["config"][event.player.index]["eyedropping"] = false
+          gui_show_frame(event.player)
+        end
+        if global["config"][event.player.index]["mode"] == "target" then
+          new_mode = "exclude"
+          global["config"][event.player.index]["eyedropping"] = false
+          gui_show_frame(event.player)
+        end
+        if global["config"][event.player.index]["mode"] == "exclude" then
+          new_mode = "normal"
+          global["config"][event.player.index]["eyedropping"] = false
+          gui_hide_frame(event.player)
+        end
         game.raise_event(FDP_EVENTS.on_mode_changed, {player = event.player, mode = new_mode})
         return
       end

--- a/gui.lua
+++ b/gui.lua
@@ -134,6 +134,17 @@ end
 
 -- Called when the player clicks the gui button
 script.on_event(FDP_EVENTS.on_gui_clicked, function(event)
+    if event.player.cursor_stack.valid_for_read then
+      if event.player.cursor_stack.name == "deconstruction-planner" then
+        --normal, target, exclude
+        local new_mode = nil
+        if global["config"][event.player.index]["mode"] == "normal" then new_mode = "target" end
+        if global["config"][event.player.index]["mode"] == "target" then new_mode = "exclude" end
+        if global["config"][event.player.index]["mode"] == "exclude" then new_mode = "normal" end
+        game.raise_event(FDP_EVENTS.on_mode_changed, {player = event.player, mode = new_mode})
+        return
+      end
+    end
     if event.player.gui.left["fdp-gui-frame"] then
       gui_hide_frame(event.player)
     else


### PR DESCRIPTION
Let me know if this is sufficient to work around the issue you mentioned in my previous PR:

> With your solution it won't be possible to open the GUI to quickly use the eyedropper tool with the planner in hand, which is something I do often.

I'll work on adding shortcut keys for switching modes, enabling/disabling eyedropper mode AND clearing the filter list in another PR. If this isn't good enough then we will just have the shortcut keys in the future.

What do you think would be good keys for the defaults? This is my idea for the modifier values.

shift+\<pick a key\> == switch modes
ctrl+\<pick a key\> == eyedropper mode toggle
ctrl+shift+\<pick a key OR a completely different key\> == clear filter list. (Alert player with chat message if GUI is hidden or always or never?)