### PR TITLE
Fix v0.15 , differentiate ('dead' or 'dry') trees from normal ('living') trees.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
-The MIT License (MIT)
+Copyright (c) 2016 Dominik Kaisers (NearlyDutch) 
+Copyright for minor edits such as v0.15 compatibility: 2017 Phezzan 
 
-Copyright (c) 2016 Dominik Kaisers (NearlyDutch)
+The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/control.lua
+++ b/control.lua
@@ -5,130 +5,130 @@ require "gui"
 
 -- Initializes the mod config
 function fdp_init_global()
-    global["config"] = global["config"] or {}
+  global["config"] = global["config"] or {}
 end
 
 -- Initializes the mod config for the given player
 function fdp_init_player(player)
-    global["config"][player.index] = global["config"][player.index] or {}
-    global["config"][player.index]["mode"] = global["config"][player.index]["mode"] or FDP_DEFAULT_FILTER_MODE
-    global["config"][player.index]["filter"] = global["config"][player.index]["filter"] or {}
-    global["config"][player.index]["eyedropping"] = global["config"][player.index]["eyedropping"] or false
+  global["config"][player.index] = global["config"][player.index] or {}
+  global["config"][player.index]["mode"] = global["config"][player.index]["mode"] or FDP_DEFAULT_FILTER_MODE
+  global["config"][player.index]["filter"] = global["config"][player.index]["filter"] or {}
+  global["config"][player.index]["eyedropping"] = global["config"][player.index]["eyedropping"] or false
 
-    gui_init(player)
+  gui_init(player)
 end
 
 -- Initializes the mod config for all players
 function fdp_init_players()
-    for _, player in pairs(game.players) do
-        fdp_init_player(player)
-    end
+  for _, player in pairs(game.players) do
+    fdp_init_player(player)
+  end
 end
 
 -- Initializes the gui for all players
 function fdp_init_gui()
-    for _, player in pairs(game.players) do
-        gui_init(player)
-    end
+  for _, player in pairs(game.players) do
+    gui_init(player)
+  end
 end
 
 -- on_init event handler
 script.on_init(function()
-    fdp_init_global()
-    fdp_init_players()
-    fdp_init_gui()
+  fdp_init_global()
+  fdp_init_players()
+  fdp_init_gui()
 end)
 
 -- on_configuration_changed event handler
 script.on_configuration_changed(function(data)
-    if not data or not data.mod_changes then
-        return
-    end
+  if not data or not data.mod_changes then
+    return
+  end
 
-    for _, player in pairs(game.players) do
-        if global ~= nil and global["config"] ~= nil and global["config"][player.index] ~= nil and global["config"][player.index]["filter"] ~= nil then
-            for i = #global["config"][player.index]["filter"], 1, -1 do
-                if not player.gui.is_valid_sprite_path(get_sprite_for_filter(global["config"][player.index]["filter"][i])) then
-                    table.remove(global["config"][player.index]["filter"], i)
-                end
-            end
+  for _, player in pairs(game.players) do
+    if global ~= nil and global["config"] ~= nil and global["config"][player.index] ~= nil and global["config"][player.index]["filter"] ~= nil then
+      for i = #global["config"][player.index]["filter"], 1, -1 do
+        if not player.gui.is_valid_sprite_path(get_sprite_for_filter(global["config"][player.index]["filter"][i])) then
+          table.remove(global["config"][player.index]["filter"], i)
         end
+      end
     end
+  end
 
-    fdp_init_global()
-    fdp_init_players()
-    fdp_init_gui()
+  fdp_init_global()
+  fdp_init_players()
+  fdp_init_gui()
 end)
 
 -- on_player_create event handler
 script.on_event(defines.events.on_player_created, function(event)
-    fdp_init_player(game.players[event.player_index])
+  fdp_init_player(game.players[event.player_index])
 end)
 
 -- on_gui_click event handler
 script.on_event(defines.events.on_gui_click, function(event)
-    local event_element = event.element.name
-    local event_player = game.players[event.player_index]
-    if not global["config"][event_player.index] then
-        fdp_init_player(event_player)
-    end
+  local event_element = event.element.name
+  local event_player = game.players[event.player_index]
+  if not global["config"][event_player.index] then
+    fdp_init_player(event_player)
+  end
 
-    local success= nil
-    local err = nil
+  local success= nil
+  local err = nil
 
-    if event_element == "fdp-gui-button" then
-        success, err = pcall(fdp_gui_clicked, {player = event_player})
-    elseif event_element == "fdp-gui-normal-checkbox" then
-        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "normal"})
-    elseif event_element == "fdp-gui-target-checkbox" then
-        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "target"})
-    elseif event_element == "fdp-gui-exclude-checkbox" then
-        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "exclude"})
-    elseif string.sub(event_element, 1, string.len("fdp-gui-filter-")) == "fdp-gui-filter-" then
-        local event_index = string.match(event_element, "fdp%-gui%-filter%-*(%d+)")
-        if event_index then
-            success, err = pcall(fdp_button_filter_clicked,  {player = event_player, index = event_index})
-        end
-    elseif event_element == "fdp-gui-eyedropper-button" then
-        success, err = pcall(fdp_button_eyedropper_clicked,  {player = event_player})
-    elseif event_element == "fdp-gui-clear-button" then
-        success, err = pcall(fdp_button_clear_clicked,  {player = event_player})
+  if event_element == "fdp-gui-button" then
+    success, err = pcall(fdp_gui_clicked, {player = event_player})
+  elseif event_element == "fdp-gui-normal-checkbox" then
+    success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "normal"})
+  elseif event_element == "fdp-gui-target-checkbox" then
+    success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "target"})
+  elseif event_element == "fdp-gui-exclude-checkbox" then
+    success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "exclude"})
+  elseif string.sub(event_element, 1, string.len("fdp-gui-filter-")) == "fdp-gui-filter-" then
+    local event_index = string.match(event_element, "fdp%-gui%-filter%-*(%d+)")
+    if event_index then
+      success, err = pcall(fdp_button_filter_clicked,  {player = event_player, index = event_index})
     end
+  elseif event_element == "fdp-gui-eyedropper-button" then
+    success, err = pcall(fdp_button_eyedropper_clicked,  {player = event_player})
+  elseif event_element == "fdp-gui-clear-button" then
+    success, err = pcall(fdp_button_clear_clicked,  {player = event_player})
+  end
 end)
 
 -- on_marked_for_deconstruction event handler
 script.on_event(defines.events.on_marked_for_deconstruction, function(event)
-    if not event.player_index then
-        return
-    end
-    local player = game.players[event.player_index]
+  if not event.player_index then
+    return
+  end
+  local player = game.players[event.player_index]
 
-    if player.cursor_stack.valid_for_read and player.cursor_stack.name ~= "deconstruction-planner" then
-        return
-    end
+  if player.cursor_stack.valid_for_read and player.cursor_stack.name ~= "deconstruction-planner" then
+    return
+  end
 
-    if not global["config"][player.index] then
-        fdp_init_player(player)
-    end
+  if not global["config"][player.index] then
+    fdp_init_player(player)
+  end
 
-    if global["config"][player.index]["mode"] == "normal" and not global["config"][player.index]["eyedropping"] then
-        return
-    end
+  if global["config"][player.index]["mode"] == "normal" and not global["config"][player.index]["eyedropping"] then
+    return
+  end
 
-    local entity_name = get_entity_name(event.entity)
-    local is_configured = is_in_filter(player, entity_name)
+  local entity_name = get_entity_name(event.entity)
+  local is_configured = is_in_filter(player, entity_name)
 
-    if global["config"][player.index]["eyedropping"] then
-        event.entity.cancel_deconstruction(player.force)
-        if not is_configured then
-            table.insert(global["config"][player.index]["filter"], entity_name)
-            gui_refresh(player)
-        end
-    else
-        if global["config"][player.index]["mode"] == "target" and not is_configured then
-            event.entity.cancel_deconstruction(player.force)
-        elseif global["config"][player.index]["mode"] == "exclude" and is_configured then
-            event.entity.cancel_deconstruction(player.force)
-        end
+  if global["config"][player.index]["eyedropping"] then
+    event.entity.cancel_deconstruction(player.force)
+    if not is_configured then
+      table.insert(global["config"][player.index]["filter"], entity_name)
+      gui_refresh(player)
     end
+  else
+    if global["config"][player.index]["mode"] == "target" and not is_configured then
+      event.entity.cancel_deconstruction(player.force)
+    elseif global["config"][player.index]["mode"] == "exclude" and is_configured then
+      event.entity.cancel_deconstruction(player.force)
+    end
+  end
 end)

--- a/control.lua
+++ b/control.lua
@@ -5,31 +5,31 @@ require "gui"
 
 -- Initializes the mod config
 function fdp_init_global()
-  global["config"] = global["config"] or {}
+    global["config"] = global["config"] or {}
 end
 
 -- Initializes the mod config for the given player
 function fdp_init_player(player)
-  global["config"][player.index] = global["config"][player.index] or {}
-  global["config"][player.index]["mode"] = global["config"][player.index]["mode"] or FDP_DEFAULT_FILTER_MODE
-  global["config"][player.index]["filter"] = global["config"][player.index]["filter"] or {}
-  global["config"][player.index]["eyedropping"] = global["config"][player.index]["eyedropping"] or false
+    global["config"][player.index] = global["config"][player.index] or {}
+    global["config"][player.index]["mode"] = global["config"][player.index]["mode"] or FDP_DEFAULT_FILTER_MODE
+    global["config"][player.index]["filter"] = global["config"][player.index]["filter"] or {}
+    global["config"][player.index]["eyedropping"] = global["config"][player.index]["eyedropping"] or false
 
-  gui_init(player)
+    gui_init(player)
 end
 
 -- Initializes the mod config for all players
 function fdp_init_players()
-  for _, player in pairs(game.players) do
-    fdp_init_player(player)
-  end
+    for _, player in pairs(game.players) do
+        fdp_init_player(player)
+    end
 end
 
 -- Initializes the gui for all players
 function fdp_init_gui()
-  for _, player in pairs(game.players) do
-    gui_init(player)
-  end
+    for _, player in pairs(game.players) do
+        gui_init(player)
+    end
 end
 
 -- on_init event handler
@@ -37,81 +37,69 @@ script.on_init(function()
     fdp_init_global()
     fdp_init_players()
     fdp_init_gui()
-  end)
+end)
 
 -- on_configuration_changed event handler
 script.on_configuration_changed(function(data)
     if not data or not data.mod_changes then
-      return
-    end
-
-    if data.mod_changes["filtered-deconstruction-planner"] and data.mod_changes["filtered-deconstruction-planner"].old_version then
-      if data.mod_changes["filtered-deconstruction-planner"].old_version < "0.4.7" then
-        global["config"] = {}
-      end
+        return
     end
 
     for _, player in pairs(game.players) do
-      if global ~= nil and global["config"] ~= nil and global["config"][player.index] ~= nil and global["config"][player.index]["filter"] ~= nil then
-        for i = #global["config"][player.index]["filter"], 1, -1 do
-          if not player.gui.is_valid_sprite_path(get_sprite_for_filter(global["config"][player.index]["filter"][i])) then
-            table.remove(global["config"][player.index]["filter"], i)
-          end
+        if global ~= nil and global["config"] ~= nil and global["config"][player.index] ~= nil and global["config"][player.index]["filter"] ~= nil then
+            for i = #global["config"][player.index]["filter"], 1, -1 do
+                if not player.gui.is_valid_sprite_path(get_sprite_for_filter(global["config"][player.index]["filter"][i])) then
+                    table.remove(global["config"][player.index]["filter"], i)
+                end
+            end
         end
-      end
     end
 
     fdp_init_global()
     fdp_init_players()
     fdp_init_gui()
-  end)
+end)
 
 -- on_player_create event handler
 script.on_event(defines.events.on_player_created, function(event)
     fdp_init_player(game.players[event.player_index])
-  end)
-
--- on_research_finished event handler
-script.on_event(defines.events.on_research_finished, function(event)
-    if event.research.name == 'automated-construction' then
-      for _, player in pairs (event.research.force.players) do
-        gui_init(player, true)
-      end
-    end
-  end)
+end)
 
 -- on_gui_click event handler
 script.on_event(defines.events.on_gui_click, function(event)
     local event_element = event.element.name
     local event_player = game.players[event.player_index]
     if not global["config"][event_player.index] then
-      fdp_init_player(event_player)
+        fdp_init_player(event_player)
     end
 
+    local success= nil
+    local err = nil
+
     if event_element == "fdp-gui-button" then
-      game.raise_event(FDP_EVENTS.on_gui_clicked, {player = event_player})
+        success, err = pcall(fdp_gui_clicked, {player = event_player})
     elseif event_element == "fdp-gui-normal-checkbox" then
-      game.raise_event(FDP_EVENTS.on_mode_changed, {player = event_player, mode = "normal"})
+        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "normal"})
     elseif event_element == "fdp-gui-target-checkbox" then
-      game.raise_event(FDP_EVENTS.on_mode_changed, {player = event_player, mode = "target"})
+        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "target"})
     elseif event_element == "fdp-gui-exclude-checkbox" then
-      game.raise_event(FDP_EVENTS.on_mode_changed, {player = event_player, mode = "exclude"})
+        success, err = pcall(fdp_mode_changed,  {player = event_player, mode = "exclude"})
     elseif string.sub(event_element, 1, string.len("fdp-gui-filter-")) == "fdp-gui-filter-" then
-      local event_index = string.match(event_element, "fdp%-gui%-filter%-*(%d+)")
-      if event_index then
-        game.raise_event(FDP_EVENTS.on_button_filter_clicked, {player = event_player, index = event_index})
-      end
+        local event_index = string.match(event_element, "fdp%-gui%-filter%-*(%d+)")
+        if event_index then
+            success, err = pcall(fdp_button_filter_clicked,  {player = event_player, index = event_index})
+        end
     elseif event_element == "fdp-gui-eyedropper-button" then
-      game.raise_event(FDP_EVENTS.on_button_eyedropper_clicked, {player = event_player})
+        success, err = pcall(fdp_button_eyedropper_clicked,  {player = event_player})
     elseif event_element == "fdp-gui-clear-button" then
-      game.raise_event(FDP_EVENTS.on_button_clear_clicked, {player = event_player})
+        success, err = pcall(fdp_button_clear_clicked,  {player = event_player})
     end
-  end)
+end)
 
 -- on_marked_for_deconstruction event handler
 script.on_event(defines.events.on_marked_for_deconstruction, function(event)
     if not event.player_index then
-      return
+        return
     end
     local player = game.players[event.player_index]
 
@@ -120,27 +108,27 @@ script.on_event(defines.events.on_marked_for_deconstruction, function(event)
     end
 
     if not global["config"][player.index] then
-      fdp_init_player(player)
+        fdp_init_player(player)
     end
 
     if global["config"][player.index]["mode"] == "normal" and not global["config"][player.index]["eyedropping"] then
-      return
+        return
     end
 
     local entity_name = get_entity_name(event.entity)
     local is_configured = is_in_filter(player, entity_name)
 
     if global["config"][player.index]["eyedropping"] then
-      event.entity.cancel_deconstruction(player.force)
-      if not is_configured then
-        table.insert(global["config"][player.index]["filter"], entity_name)
-        gui_refresh(player)
-      end
+        event.entity.cancel_deconstruction(player.force)
+        if not is_configured then
+            table.insert(global["config"][player.index]["filter"], entity_name)
+            gui_refresh(player)
+        end
     else
-      if global["config"][player.index]["mode"] == "target" and not is_configured then
-        event.entity.cancel_deconstruction(player.force)
-      elseif global["config"][player.index]["mode"] == "exclude" and is_configured then
-        event.entity.cancel_deconstruction(player.force)
-      end
+        if global["config"][player.index]["mode"] == "target" and not is_configured then
+            event.entity.cancel_deconstruction(player.force)
+        elseif global["config"][player.index]["mode"] == "exclude" and is_configured then
+            event.entity.cancel_deconstruction(player.force)
+        end
     end
-  end)
+end)

--- a/gui.lua
+++ b/gui.lua
@@ -1,8 +1,7 @@
 -- Intializes the top button GUI element for the given player
-function gui_init(player, researched)
-  researched = researched or false
+function gui_init(player)
 
-  if (not player.gui.top["fdp-gui-button"]) and (player.force.technologies["automated-construction"].researched or researched) then
+  if (not player.gui.top["fdp-gui-button"]) then
     player.gui.top.add{
       type = "button",
       name = "fdp-gui-button",
@@ -133,43 +132,43 @@ function gui_refresh(player)
 end
 
 -- Called when the player clicks the gui button
-script.on_event(FDP_EVENTS.on_gui_clicked, function(event)
+function fdp_gui_clicked(event)
     if event.player.gui.left["fdp-gui-frame"] then
-      gui_hide_frame(event.player)
+        gui_hide_frame(event.player)
     else
-      gui_show_frame(event.player)
+        gui_show_frame(event.player)
     end
-  end)
+end
 
 -- Called when the player changes the mode
-script.on_event(FDP_EVENTS.on_mode_changed, function(event)
+function fdp_mode_changed(event)
     global["config"][event.player.index]["mode"] = event.mode
     gui_refresh(event.player)
-  end)
+end
 
 -- Called when the player clicks a filter icon
-script.on_event(FDP_EVENTS.on_button_filter_clicked, function(event)
+function fdp_button_filter_clicked(event)
     if not event.player.cursor_stack.valid_for_read then
-      table.remove(global["config"][event.player.index]["filter"], event.index)
-    else
-      if is_in_filter(event.player, event.player.cursor_stack.name) then
-        event.player.print({"fdp-error-duplicate"})
-      else
         table.remove(global["config"][event.player.index]["filter"], event.index)
-        table.insert(global["config"][event.player.index]["filter"], event.index, event.player.cursor_stack.name)
-      end
+    else
+        if is_in_filter(event.player, event.player.cursor_stack.name) then
+            event.player.print({"fdp-error-duplicate"})
+        else
+            table.remove(global["config"][event.player.index]["filter"], event.index)
+            table.insert(global["config"][event.player.index]["filter"], event.index, event.player.cursor_stack.name)
+        end
     end
     gui_refresh(event.player)
-  end)
+end
 
 -- Called when the player clicks the eyedropper button
-script.on_event(FDP_EVENTS.on_button_eyedropper_clicked, function(event)
+function fdp_button_eyedropper_clicked(event)
     global["config"][event.player.index]["eyedropping"] = not global["config"][event.player.index]["eyedropping"]
     gui_refresh(event.player)
-  end)
+end
 
 -- Called when the player clicks the clear button
-script.on_event(FDP_EVENTS.on_button_clear_clicked, function(event)
+function fdp_button_clear_clicked(event)
     global["config"][event.player.index]["filter"] = {}
     gui_refresh(event.player)
-  end)
+end

--- a/gui.lua
+++ b/gui.lua
@@ -133,42 +133,42 @@ end
 
 -- Called when the player clicks the gui button
 function fdp_gui_clicked(event)
-    if event.player.gui.left["fdp-gui-frame"] then
-        gui_hide_frame(event.player)
-    else
-        gui_show_frame(event.player)
-    end
+  if event.player.gui.left["fdp-gui-frame"] then
+    gui_hide_frame(event.player)
+  else
+    gui_show_frame(event.player)
+  end
 end
 
 -- Called when the player changes the mode
 function fdp_mode_changed(event)
-    global["config"][event.player.index]["mode"] = event.mode
-    gui_refresh(event.player)
+  global["config"][event.player.index]["mode"] = event.mode
+  gui_refresh(event.player)
 end
 
 -- Called when the player clicks a filter icon
 function fdp_button_filter_clicked(event)
-    if not event.player.cursor_stack.valid_for_read then
-        table.remove(global["config"][event.player.index]["filter"], event.index)
+  if not event.player.cursor_stack.valid_for_read then
+    table.remove(global["config"][event.player.index]["filter"], event.index)
+  else
+    if is_in_filter(event.player, event.player.cursor_stack.name) then
+      event.player.print({"fdp-error-duplicate"})
     else
-        if is_in_filter(event.player, event.player.cursor_stack.name) then
-            event.player.print({"fdp-error-duplicate"})
-        else
-            table.remove(global["config"][event.player.index]["filter"], event.index)
-            table.insert(global["config"][event.player.index]["filter"], event.index, event.player.cursor_stack.name)
-        end
+      table.remove(global["config"][event.player.index]["filter"], event.index)
+      table.insert(global["config"][event.player.index]["filter"], event.index, event.player.cursor_stack.name)
     end
-    gui_refresh(event.player)
+  end
+  gui_refresh(event.player)
 end
 
 -- Called when the player clicks the eyedropper button
 function fdp_button_eyedropper_clicked(event)
-    global["config"][event.player.index]["eyedropping"] = not global["config"][event.player.index]["eyedropping"]
-    gui_refresh(event.player)
+  global["config"][event.player.index]["eyedropping"] = not global["config"][event.player.index]["eyedropping"]
+  gui_refresh(event.player)
 end
 
 -- Called when the player clicks the clear button
 function fdp_button_clear_clicked(event)
-    global["config"][event.player.index]["filter"] = {}
-    gui_refresh(event.player)
+  global["config"][event.player.index]["filter"] = {}
+  gui_refresh(event.player)
 end

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "filtered-deconstruction-planner",
-  "version": "0.4.10",
-  "factorio_version": "0.14",
+  "version": "0.4.11",
+  "factorio_version": "0.15",
   "title": "Filtered Deconstruction Planner",
   "author": "Dominik Kaisers (NearlyDutch)",
   "homepage": "https://github.com/dkaisers/filtered-deconstruction-planner",

--- a/lib.lua
+++ b/lib.lua
@@ -10,7 +10,13 @@ function get_entity_name(entity)
   elseif entity.name == "deconstructible-tile-proxy" then
     return entity.surface.get_tile(entity.position.x, entity.position.y).prototype.mineable_properties.products[1].name
   elseif entity.type == "tree" then
-    return "fdp-tree-proxy"
+      if string.sub(entity.name, 1, 4) == "dead" then
+          return "fdp-dead-proxy"
+      elseif string.sub(entity.name, 1, 3) == "dry" then
+          return "fdp-dead-proxy"
+      else 
+          return "fdp-tree-proxy"
+      end
   else
     return entity.name
   end
@@ -20,6 +26,8 @@ end
 function get_sprite_for_filter(filter)
   if filter == "" then
     return ""
+  elseif filter == "fdp-dead-proxy" then
+      return "entity/dead-grey-trunk"
   elseif filter == "fdp-tree-proxy" then
     return "entity/tree-03"
   elseif filter == "stone-rock" then

--- a/lib.lua
+++ b/lib.lua
@@ -10,13 +10,13 @@ function get_entity_name(entity)
   elseif entity.name == "deconstructible-tile-proxy" then
     return entity.surface.get_tile(entity.position.x, entity.position.y).prototype.mineable_properties.products[1].name
   elseif entity.type == "tree" then
-      if string.sub(entity.name, 1, 4) == "dead" then
-          return "fdp-dead-proxy"
-      elseif string.sub(entity.name, 1, 3) == "dry" then
-          return "fdp-dead-proxy"
-      else 
-          return "fdp-tree-proxy"
-      end
+    if string.sub(entity.name, 1, 4) == "dead" then
+      return "fdp-dead-proxy"
+    elseif string.sub(entity.name, 1, 3) == "dry" then
+      return "fdp-dead-proxy"
+    else 
+      return "fdp-tree-proxy"
+    end
   else
     return entity.name
   end
@@ -27,7 +27,7 @@ function get_sprite_for_filter(filter)
   if filter == "" then
     return ""
   elseif filter == "fdp-dead-proxy" then
-      return "entity/dead-grey-trunk"
+    return "entity/dead-grey-trunk"
   elseif filter == "fdp-tree-proxy" then
     return "entity/tree-03"
   elseif filter == "stone-rock" then


### PR DESCRIPTION
I couldn't live without the filter, so here's a little update I made to carry this excellent mod into v0.15 .

- remove 'automated-construction' technology requirement  (v0.15 compatibility)
- replace manually calling custom 'events' from on_gui_click() with pcall()
- separate 'dead' and 'dry' from 'normal' trees, use the dead-trunk sprite (see lib.lua)

I tried to do right by the whitespace... but it wasn't consistent to begin with. Sorry.